### PR TITLE
Made result output more readable

### DIFF
--- a/app/command/result.js
+++ b/app/command/result.js
@@ -22,13 +22,7 @@ class Result {
 			'response_type': 'in_channel',
 			'attachments': [
 				{
-					'text':
-						'red1 = ' + match.red1 + '; ' +
-						'red2 = ' + match.red2 + '; ' +
-						'redScore = ' + match.redScore + '; ' +
-						'blueScore = ' + match.blueScore + '; ' +
-						'blue1 = ' + match.blue1 + '; ' +
-						'blue2 = ' + match.blue2 + ';'
+					'text': match.toString()
 				}
 			]
 		};


### PR DESCRIPTION
I've simply used the `toString()` function provided by `match`. The current output is pretty unreadable.
