### PR TITLE
Closes #28: /fb aliases should be in private.

### DIFF
--- a/app/command/aliases.js
+++ b/app/command/aliases.js
@@ -21,8 +21,7 @@ class Aliases {
 		}
 
 		return {
-			'text': '```' + table.toString() + '```',
-			'response_type': 'in_channel'
+			'text': '```' + table.toString() + '```'
 		};
 	}
 }


### PR DESCRIPTION
Closes #28: /fb aliases should be in private.
